### PR TITLE
os: '/opt/bin/e' created to simplify 'etcdctl' usage (sets proper key/certs)

### DIFF
--- a/os/templates/flatcar.yaml
+++ b/os/templates/flatcar.yaml
@@ -40,6 +40,15 @@ storage:
           REBOOT_WINDOW_LENGTH=1h
       mode: 0644
 {{- if eq $e.k3s "etcd" }}
+    - path: /opt/bin/e
+      overwrite: true
+      contents:
+        inline: |
+          #!/bin/bash
+          # e get / --prefix -w json | jq .
+          D="/var/lib/rancher/k3s/server/tls/etcd"
+          exec etcdctl --key=${D}/client.key --cert=${D}/client.crt --cacert=${D}/server-ca.crt "$@"
+      mode: 0755
     # https://docs.k3s.io/installation/configuration
     - path: /etc/rancher/k3s/config.yaml
       overwrite: true


### PR DESCRIPTION
It's done: **/opt/bin/e** is generated with the following content:
```
core@fc1 ~ $ ls -l /opt/bin/e
-rwxr-xr-x. 1 root root 178 Nov 27 17:07 /opt/bin/e

core@fc1 ~ $ cat /opt/bin/e
#!/bin/bash
# e get / --prefix -w json | jq .
D="/var/lib/rancher/k3s/server/tls/etcd"
exec etcdctl --key=${D}/client.key --cert=${D}/client.crt --cacert=${D}/server-ca.crt "$@"
```
It works fine:
```
core@fc1 ~ $ sudo e get / --prefix -w json | jq .header.revision
1805
```