### PR TITLE
os: 'k3s_agent_token' defined in addition to 'k3s_token' to isolate role credentials

### DIFF
--- a/os/secrets.yaml
+++ b/os/secrets.yaml
@@ -8,6 +8,7 @@ env:
             - ENC[AES256_GCM,data:xpgUmIFnkA9NKcPBcQ==,iv:Fm+ox6gSZXtcCwwZrR63B/5aUmuUZ9Cq7MYxfa4jjGw=,tag:+8tWlPaEW2Y+GgCBqYq45g==,type:str]
         k3s: ENC[AES256_GCM,data:ZDoq,iv:6QaBFUo5ok9plbGGafGfCDW/3kLpPCrYjwZzVYU5yic=,tag:jb1PCzdV6fy9YGAK2TsmGg==,type:str]
         k3s_token: ENC[AES256_GCM,data:f8sKQRldIm7vG2MR0DK4cFOc2VA731QxsxgFQPHMTg+HICaH,iv:FxbcmrvPkiNl/MfFrYeHPWHwvI9MOoYaDf44QjbzD8k=,tag:VRhDQyk8Ev+26dbsn+3JXw==,type:str]
+        k3s_agent_token: ENC[AES256_GCM,data:R2GP00CD0eZvsI8AN3xTRTfwAxjeYyhKq0WSHJd0YRQZwGi6,iv:lpDY2a+VE5lrND/nVP79o/Ya/n0M187fUo9PpPRVtrA=,tag:GiO1y6wPjHr9kS/HtHnX8A==,type:str]
     prod:
         ssh_authorized_keys:
             - ENC[AES256_GCM,data:CgdYn9P0J/dkTVfdetHZzB3LWUOXlEWeGwkPpF73+Xi4piHCV7v2VFSVybyJIBp+FB6OVENx0ma0xvvY4J0aOmvuieH7TsndLN/1Ou8X0b09tzLxO5Lj2L5DDNmUBPp0HsAVDaCU8Y+S0ipFpJnFA0f0U9IAdzYrPEWbs7gEmmJooKOYu87BSrLhvimp25KVLC1ouEAh+iZwzRlA1MfCj7A9oNCzj54hi4zTmt+IEgKp45qTz5aPKAq+wsj9CGdB9pbg59g5MMeVxCj8tL6InPYazVPpz6EkJRtTR6I3K1pf3XAxby4OAGvGTePQnV3+aYRsGeXYzdBYISrh14WojMqM8cfY5Listdp5y8ReiIRrl0zORCQNnkCWnc1fqcZboVFEK2xU4okX2M9e3rZd861XgPCwvjp+7hr27k5OFt0wyRja0rAEIvsFl0D8oUjFPG9g9PJyYq02SvrY+yyJUQx3ayYl/Qsx1AwpPiC6LFPbHJaJsckIOaCv6V5ySp0fiirXwilKY3vIt1V548USwg==,iv:ikPHhdaHwSxFYzktRjN2umfzWY1mbJNKKzqYMeKz3Ss=,tag:jOS8ma6yqRkYkmscwhIcCg==,type:str]
@@ -15,6 +16,7 @@ env:
             - ENC[AES256_GCM,data:KVLnV1Dr7jIaHThQdw==,iv:MybJ1mmQqmT9DcuzgXOXmSOfvCYZSvjlJnMlTGYYsTY=,tag:I4eZbmMSYmNq4UKnrTbf5w==,type:str]
         k3s: ENC[AES256_GCM,data:cy/B,iv:u1KQqlNPfw/QussYaW5Ub77qo2EM0GmqEHwZ256HyOc=,tag:TBV9xc5kLdw7yr9ALKE03w==,type:str]
         k3s_token: ENC[AES256_GCM,data:svSA98kERwS10wo9ST4UR1XdbtEfeJ6Be7LZR8ed1MhywVko,iv:GILNkpSaZsaaD6kRZ5N49eiGs9zIl7GxW8MkIEmrxLU=,tag:i2HkwVPntyMKkXLDw0ur1w==,type:str]
+        k3s_agent_token: ENC[AES256_GCM,data:c3jC/AvmFVcwV613KHtp7PmP6E5EKp9W13BcxC5ckwP0016m,iv:uVTvFGyrRQhjnT8sUmRHZoWhX8I8ZsYd0WSV3gRh3DE=,tag:bSSr2T9UVDzurMX6bMtBCQ==,type:str]
 sops:
     age:
         - recipient: age1kuk0xhyha5ecs4hfwu7htj7xkwsxjq70runwm9lmxq3z8gumxgwq4m74j2
@@ -26,7 +28,7 @@ sops:
             cUMzdC9PNnRuV2ZrNUVTTTUrQk1McFEK7p9k6W5d1VS+qgFNODT6QNDMvjINSXlT
             Olyvkh5QsNQ5EzDsGuvYvQeA0KVKUccv7vv18g4mjHLLRIrVEgNmNw==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2025-11-23T10:45:26Z"
-    mac: ENC[AES256_GCM,data:oly1RJRK6u7ZXMC9cit4pflZLsivoV2Ro14E6z8ZfjKIsHEBS7pQ+vaxxZQdXZRxjIio+10M+sBixOrb42bvHH7d4ks59Pjk3EEWyEJx/ezjSJC615ObpuNGw79wHWvX1o2w9wIkBqAU5FCnlp6apmyfVR6pyhlQ4uRqfap05MY=,iv:QgLH7+CxFg/gMCJm6a3TBCOda57w8EZYpLb/R3i3s1c=,tag:3lfj9j98tdSce/uEQLaQ7A==,type:str]
+    lastmodified: "2025-11-27T17:31:59Z"
+    mac: ENC[AES256_GCM,data:TEiY57cA/TbaSg2DrgWo8+WT/8mZf+8yKYR6eh6nelf21pO7gXsCyZ5bdpNer6l9X2XNOIrxViyjKyS6xXLtE0NxaQrK11wbqLuO6QSr76eFiHbMJsx6xE900pA2Ht9zi3E9fCy8y27Ti7/VGKmeCTxZDe07tgdZSoBBrAPmBEY=,iv:iPpk9AShG+3Xmcg71nSaZ94pOZc0Rn/oUzraMav09Fs=,tag:YADnRNvHn1zOKFzxtiqLzg==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.11.0

--- a/os/templates/flatcar.yaml
+++ b/os/templates/flatcar.yaml
@@ -54,13 +54,18 @@ storage:
       overwrite: true
       contents:
         inline: |
+{{- if eq $k3s_cmd "server" }}
           token: {{ required "k3s_token missing" $e.k3s_token | quote }}
-          node-ip: {{ $target | quote }}
+          agent-token: {{ required "k3s_agent_token missing" $e.k3s_agent_token | quote }}
+{{- else }}
+          token: {{ required "k3s_agent_token missing" $e.k3s_agent_token | quote }}
+{{- end }}
 {{- if eq $position 1 }}
           cluster-init: true
 {{- else }}
           server: {{ $k3s_url | quote }}
 {{- end }}
+          node-ip: {{ $target | quote }}
       mode: 0600
 {{- end }}
 

--- a/os/values.yaml
+++ b/os/values.yaml
@@ -8,6 +8,7 @@ env:
     - 192.168.56.53
     k3s: off
     k3s_token: "token-dev-insecure"
+    k3s_agent_token: "agent-token-dev-insecure"
   prod:
     ssh_authorized_keys:
     - "ssh-rsa PROD..."
@@ -15,3 +16,4 @@ env:
     - 192.168.56.51
     k3s: off
     k3s_token: "token-pro-insecure"
+    k3s_agent_token: "agent-token-pro-insecure"


### PR DESCRIPTION
It's done:

- **k3s_agent_token** created to authenticate **agents** to **servers**
- **k3s_token** used to only authenticate **servers** to **servers**