### PR TITLE
os: '/etc/extensions/containerd-flatcar.raw' disabled

### DIFF
--- a/os/templates/flatcar.yaml
+++ b/os/templates/flatcar.yaml
@@ -30,6 +30,11 @@ systemd:
 {{- end }}
 
 storage:
+  links:
+    # https://www.flatcar.org/docs/latest/provisioning/sysext/
+    - path: /etc/extensions/containerd-flatcar.raw
+      target: /dev/null
+      overwrite: true
   files:
     - path: /etc/flatcar/update.conf
       overwrite: true


### PR DESCRIPTION
It's done: **/etc/extensions/containerd-flatcar.raw** has been disabled

Result: **/etc/extensions/containerd-flatcar.raw** link target updated from **/usr/share/flatcar/sysext/containerd-flatcar.raw** to **/dev/null**:
```
core@fc4 ~ $ ls -l /etc/extensions/
total 4
lrwxrwxrwx. 1 root root  9 Nov 27 19:09 containerd-flatcar.raw -> /dev/null
lrwxrwxrwx. 1 root root 44 Nov 23 22:06 docker-flatcar.raw -> /usr/share/flatcar/sysext/docker-flatcar.raw

core@fc4 ~ $ ls -l /usr/share/flatcar/sysext/
total 119772
-rw-r--r--. 1 root root 65822720 Nov 23 22:06 containerd-flatcar.raw
-rw-r--r--. 1 root root 56823808 Nov 23 22:06 docker-flatcar.raw
```

Besides that containerd is not active anymore