### PR TITLE
os: 'flannel.interface' supported to set 'flannel-iface' when needed

### DIFF
--- a/os/templates/storage-files/_etc-rancher-k3s-config-yaml.yaml
+++ b/os/templates/storage-files/_etc-rancher-k3s-config-yaml.yaml
@@ -9,6 +9,7 @@
 {{- $vip := get $kube_vip "vip" | default "" -}}
 {{- $targets := required "targets missing" $e.targets -}}
 {{- $k3s_url := eq $vip "" | ternary ($targets | first) $vip | printf "https://%s:6443" -}}
+{{- $flannel_iface := $e | dig "flannel" "interface" "" -}}
 # https://docs.k3s.io/installation/configuration
 - path: /etc/rancher/k3s/config.yaml
   overwrite: true
@@ -31,5 +32,8 @@
       server: {{ $k3s_url | quote }}
     {{- end }}
       node-ip: {{ $target | quote }}
+    {{- if $flannel_iface }}
+      flannel-iface: {{ $flannel_iface | quote }}
+    {{- end }}
   mode: 0600
 {{- end }}

--- a/os/values.yaml
+++ b/os/values.yaml
@@ -13,6 +13,8 @@ env:
       vip: 192.168.56.50
       interface: enp0s8
       kvversion: v1.0.2
+    flannel:
+      interface: enp0s8
   prod:
     ssh_authorized_keys:
     - "ssh-rsa PROD..."


### PR DESCRIPTION
It's fixed:

- **/etc/rancher/k3s/config.yaml → flannel-iface** set to **enp0s8** (internal interface)
- Using this configuration every pod can ping each other (e.g. busybox pod)