### PR TITLE
os: prometheus scrape_interval/evaluation_interval reduced from 1m to 30s

### DIFF
--- a/os/templates/storage-files/_prometheus-yaml.yaml
+++ b/os/templates/storage-files/_prometheus-yaml.yaml
@@ -32,6 +32,12 @@ metadata:
   namespace: kube-system
 spec:
   valuesContent: |-
+    server:
+      global:
+        # default: scrape_interval/scrape_timeout/evaluation_interval=1m/10s/1m
+        scrape_interval: 30s
+        scrape_timeout: 10s
+        evaluation_interval: 30s
     serverFiles:
       alerting_rules.yml:
         groups:


### PR DESCRIPTION
It's done:

- **scrape_interval**: reduced from **1m** to **30s**
- **scrape_timeout**: enforced to **10s** (default value)
- **evaluation_interval**: reduced from **1m** to **30s**