### PR TITLE
os: '/etc/extensions/docker-flatcar.raw' disabled

### DIFF
--- a/os/templates/flatcar.yaml
+++ b/os/templates/flatcar.yaml
@@ -18,6 +18,7 @@ systemd:
 storage:
   links:
     {{- include "os.storage.links.containerd.flatcar.raw" . | nindent 4 }}
+    {{- include "os.storage.links.docker.flatcar.raw" . | nindent 4 }}
   files:
     {{- include "os.storage.files.etc.flatcar.update.conf" . | nindent 4 }}
     {{- if eq $e.k3s "etcd" }}

--- a/os/templates/storage-links/_docker-flatcar-raw.yaml
+++ b/os/templates/storage-links/_docker-flatcar-raw.yaml
@@ -1,0 +1,6 @@
+{{- define "os.storage.links.docker.flatcar.raw" -}}
+# https://www.flatcar.org/docs/latest/provisioning/sysext/
+- path: /etc/extensions/docker-flatcar.raw
+  target: /dev/null
+  overwrite: true
+{{- end }}


### PR DESCRIPTION
It's done:

- **/etc/extensions/docker-flatcar.raw** removed (linked to **/dev/null**)
- Ref: https://www.flatcar.org/docs/latest/provisioning/sysext/