### PR TITLE
genesis: 'flatcar.yaml' uses both 'i12e_sha256sum' and 'i12e_version' params

### DIFF
--- a/genesis/app/butane.py
+++ b/genesis/app/butane.py
@@ -14,6 +14,9 @@ O_BASH_RAW = "bash_raw"
 O_IGNITION = "ignition"
 O_DEBUG = "debug"
 
+I12E_VERSION = "v0.0.13"
+I12E_SHA256SUM = "4261b579bb5754272597b11949f0b95c3877cc9003fb9ac19fc4a2effc7ba488"
+
 class Butane(object):
     def __init__(self,args):
         self.__cfg = Config().main_config()
@@ -39,6 +42,8 @@ class Butane(object):
 
     def __ignition(self):
         buf = self.__tpl.render(
+            i12e_version = I12E_VERSION,
+            i12e_sha256sum = I12E_SHA256SUM,
             mode = self.__mode,
             k3s_version = self.__k3s_version,
             ssh_authorized_keys = self.__ssh_authorized_keys,

--- a/genesis/app/templates/flatcar.yaml
+++ b/genesis/app/templates/flatcar.yaml
@@ -13,7 +13,7 @@ systemd:
       Type=simple
       Restart=always
       RestartSec=5s
-      ExecStartPre=/bin/sh -c 'set -e -x -o pipefail ; echo "4261b579bb5754272597b11949f0b95c3877cc9003fb9ac19fc4a2effc7ba488  /etc/extensions/i12e-flatcar.raw" | sha256sum -c'
+      ExecStartPre=/bin/sh -c 'set -e -x -o pipefail ; echo "{{ i12e_sha256sum }}  /etc/extensions/i12e-flatcar.raw" | sha256sum -c'
       ExecStart=/bin/sh -c 'if [ -x /opt/bin/i12e ]; then exec /opt/bin/i12e; else exec /usr/bin/i12e; fi'
       [Install]
       WantedBy=multi-user.target
@@ -45,7 +45,7 @@ storage:
     group:
       name: root
     contents:
-      source: https://github.com/sfmunoz/i12e/releases/download/v0.0.13/i12e-flatcar.raw
+      source: https://github.com/sfmunoz/i12e/releases/download/{{ i12e_version }}/i12e-flatcar.raw
   - path: /root/.config/rclone/rclone.conf
     overwrite: true
     mode: 0600


### PR DESCRIPTION
It's done: both **i12e_sha256sum** and **i12e_version** are **flatcar.yaml** params defined by **butane.py** (hardcoded)