### PR TITLE
flatcar.yaml: 'ExecStart=/usr/bin/i12e' used instead of '/opt/bin/i12e' vs '/usr/bin/i12e' selector

### DIFF
--- a/genesis/app/templates/flatcar.yaml
+++ b/genesis/app/templates/flatcar.yaml
@@ -14,7 +14,7 @@ systemd:
       Restart=always
       RestartSec=5s
       ExecStartPre=/bin/sh -c 'set -e -x -o pipefail ; echo "{{ i12e_sha256sum }}  /etc/extensions/i12e-flatcar.raw" | sha256sum -c'
-      ExecStart=/bin/sh -c 'if [ -x /opt/bin/i12e ]; then exec /opt/bin/i12e; else exec /usr/bin/i12e; fi'
+      ExecStart=/usr/bin/i12e
       [Install]
       WantedBy=multi-user.target
 storage:


### PR DESCRIPTION
It's done:

- Old: `ExecStart=/bin/sh -c 'if [ -x /opt/bin/i12e ]; then exec /opt/bin/i12e; else exec /usr/bin/i12e; fi'`
- Now: `ExecStart=/usr/bin/i12e`
- No release generated provided that is **flatcar.yaml** related → **/etc/extensions/i12e-flatcar.raw** is not affected