### PR TITLE
genesis: 'BUTANE_K3S_VERSION_DEFAULT=v1.34.3+k3s1' removed from '__main__.py'

### DIFF
--- a/genesis/app/__main__.py
+++ b/genesis/app/__main__.py
@@ -9,7 +9,6 @@ from .artifact import Artifact
 basicConfig(format='%(asctime)s [%(relativeCreated)7.0f] [%(levelname).1s] %(message)s (%(module)s:%(lineno)d)',level=INFO,stream=sys.stderr)
 log = getLogger(__name__)
 
-BUTANE_K3S_VERSION_DEFAULT = "v1.34.3+k3s1"
 BUTANE_VALID_MODES = ["main","server","agent"]
 BUTANE_DEFAULT_MODE = "main"
 BUTANE_VALID_OUTPUTS = ["ignition","bash_b64","bash_raw","debug"]


### PR DESCRIPTION
It's done:

- **BUTANE_K3S_VERSION_DEFAULT=v1.34.3+k3s1** has been removed from **genesis → __main__.py** to avoid confusions
  - No release has been generated provided that it's an artifact change (**/etc/extensions/i12e-flatcar.raw** doesn't change)
- It's hardcoded in **/opt/libexec/i12e/artifact-tune.sh → k3s_install()** which is OK for now
  - That is an **artifact** file that can be changed anytime
  - There's no reason to move it because it's meant to stay still for a reasonable amount of time 
  - It could be moved to **/etc/i12e/** but doesn't make any difference now