### PR TITLE
genesis: 'flatcar-reset' preserves '/home/core/.bash_history' and '/root/.bash_history'

### DIFF
--- a/genesis/app/butane.py
+++ b/genesis/app/butane.py
@@ -98,6 +98,8 @@ class Butane(object):
                     "'/etc/ssh/ssh_host_.*'",
                     "/var/log",
                     "/var/lib/rancher/k3s/agent/containerd",
+                    "/home/core/.bash_history",
+                    "/root/.bash_history",
                     "-F",
                     "/dev/stdin",
                 ]),


### PR DESCRIPTION
It's done: both **/home/core/.bash_history** and **/root/.bash_history** are preserved by **flatcar-reset**