### PR TITLE
i12e: 'b64Gzip()' fixed by deferring 'Close()' calls

### DIFF
--- a/internal/butane/aux.go
+++ b/internal/butane/aux.go
@@ -24,15 +24,11 @@ func tplNew(fname string, addFuncs bool) (*template.Template, error) {
 func b64Gzip(ibuf *bytes.Buffer) (*bytes.Buffer, error) {
 	var ret bytes.Buffer
 	b64Enc := base64.NewEncoder(base64.StdEncoding, &ret)
+	defer b64Enc.Close()
 	gzEnc := gzip.NewWriter(b64Enc)
+	defer gzEnc.Close()
 	_, err := gzEnc.Write(ibuf.Bytes())
 	if err != nil {
-		return nil, err
-	}
-	if err := gzEnc.Close(); err != nil {
-		return nil, err
-	}
-	if err := b64Enc.Close(); err != nil {
 		return nil, err
 	}
 	return &ret, nil


### PR DESCRIPTION
**b64Gzip()** has been fixed by deferring **Close()** calls