### PR TITLE
nftables: 'jump input_public' applied to 'iifname' not in ['lo','veth*','cni*','flannel']

### DIFF
--- a/internal/artifact/templates/nftables.conf
+++ b/internal/artifact/templates/nftables.conf
@@ -12,7 +12,7 @@ table inet filter {
   set k6_bid { type ipv6_addr . inet_service; timeout 10s; }
   chain input {
     type filter hook input priority raw; policy drop;
-    iifname {"eth*"} jump input_public
+    iifname != {"lo","veth*","cni*","flannel*"} jump input_public
     counter accept
   }
   chain forward {


### PR DESCRIPTION
It's done and nftables logic has been revert

#156 has been opened to design network communication