### PR TITLE
Fix/205 rustfs run loop

### DIFF
--- a/fileserver/run.sh
+++ b/fileserver/run.sh
@@ -12,6 +12,9 @@ sudo -u root chown -R 10001:10001 data logs
 { set +x; } 2>/dev/null
 set +e
 
+DATA_FOLDER="$(pwd)/data"
+LOGS_FOLDER="$(pwd)/logs"
+
 while true; do
   set -x
   docker run \
@@ -22,8 +25,8 @@ while true; do
     -p 127.0.0.1:9001:9001 \
     -p 192.168.56.1:9000:9000 \
     -p 192.168.56.1:9001:9001 \
-    -v $(pwd)/data:/data \
-    -v $(pwd)/logs:/logs \
+    -v ${DATA_FOLDER}:/data \
+    -v ${LOGS_FOLDER}:/logs \
     rustfs/rustfs:latest
   { set +x; } 2>/dev/null
   echo "waiting 1s to try again..."


### PR DESCRIPTION
It's done:

- **fileserver/run.sh** runs **docker run ...** in a loop to keep trying until the network is available
- Output clutter has been removed