### PR TITLE
i12e: 'I12eYaml()', 'I12eEncYaml()' and 'ButaneEncYaml()' moved from 'Config' to 'Env'

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -60,12 +60,12 @@ i12e is an infrastructure management tool for task automation:
 				v.BindPFlag("butane.mode", cmd.Flags().Lookup("mode"))
 				v.BindPFlag("butane.output", cmd.Flags().Lookup("output"))
 			}
-			fp, err := os.Open(cfg.I12eYaml())
+			fp, err := os.Open(cfg.Env.I12eYaml())
 			if err != nil {
 				return err
 			}
 			defer fp.Close()
-			bufOut, bufErr, err := cmdutil.RunSimple(exec.Command("sops", "decrypt", cfg.I12eEncYaml()))
+			bufOut, bufErr, err := cmdutil.RunSimple(exec.Command("sops", "decrypt", cfg.Env.I12eEncYaml()))
 			if err != nil {
 				return fmt.Errorf("'sops decrypt' failed: err=%s; buf_err=%s", err, bufErr)
 			}

--- a/internal/butane/butane.go
+++ b/internal/butane/butane.go
@@ -35,7 +35,7 @@ func (b *Butane) butaneCmd() *exec.Cmd {
 }
 
 func (b *Butane) ignitionConfigMergeSource() (*bytes.Buffer, error) {
-	fname := b.cfg.ButaneEncYaml()
+	fname := b.cfg.Env.ButaneEncYaml()
 	_, err := os.Stat(fname)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"fmt"
 	"net/netip"
 	"time"
 
@@ -67,23 +66,4 @@ func (cfg *Config) Validate() error {
 		return err
 	}
 	return nil
-}
-
-func (c *Config) ButaneEncYaml() string {
-	return c.fname("butane.enc.yaml")
-}
-
-func (c *Config) I12eYaml() string {
-	return c.fname("i12e.yaml")
-}
-
-func (c *Config) I12eEncYaml() string {
-	return c.fname("i12e.enc.yaml")
-}
-
-func (c *Config) fname(bname string) string {
-	if c.Env == EnvNone {
-		return fmt.Sprintf("/etc/i12e/%s", bname)
-	}
-	return fmt.Sprintf("config/%s/%s", c.Env.String(), bname)
 }

--- a/internal/config/env.go
+++ b/internal/config/env.go
@@ -14,10 +14,6 @@ const (
 
 var envs = []Env{EnvNone, EnvDev, EnvProd}
 
-func (e Env) String() string {
-	return string(e)
-}
-
 func ValidEnvs() []string {
 	ret := make([]string, len(envs))
 	for i, v := range envs {
@@ -33,4 +29,27 @@ func GetEnv(e string) (Env, error) {
 		}
 	}
 	return EnvNone, fmt.Errorf("unknown env '%s' (valid: %q)", e, ValidEnvs())
+}
+
+func (e Env) String() string {
+	return string(e)
+}
+
+func (e Env) ButaneEncYaml() string {
+	return e.fname("butane.enc.yaml")
+}
+
+func (e Env) I12eYaml() string {
+	return e.fname("i12e.yaml")
+}
+
+func (e Env) I12eEncYaml() string {
+	return e.fname("i12e.enc.yaml")
+}
+
+func (e Env) fname(bname string) string {
+	if e == EnvNone {
+		return fmt.Sprintf("/etc/i12e/%s", bname)
+	}
+	return fmt.Sprintf("config/%s/%s", e.String(), bname)
 }


### PR DESCRIPTION
It's done:  the following methods have been moved from **Config** to **Env**:

- I12eYaml()
- I12eEncYaml()
- ButaneEncYaml()