### PR TITLE
Enh/230 rustfs binary

### DIFF
--- a/fileserver/run.sh
+++ b/fileserver/run.sh
@@ -8,15 +8,18 @@
 #     $ ./rustfs --version
 #
 
+VERSION="1.0.0-alpha.83"
+SHA256SUM="b3fbf4e0dbdede70fc774719509181229f747d987571815de1f7163d511b1d9f"
+
 set -e -o pipefail
 cd "$(dirname "$0")"
 
 if [ ! -f rustfs ]; then
   set -x
-  curl -LO https://github.com/rustfs/rustfs/releases/download/1.0.0-alpha.83/rustfs-linux-x86_64-gnu-v1.0.0-alpha.83.zip
-  echo "b3fbf4e0dbdede70fc774719509181229f747d987571815de1f7163d511b1d9f  rustfs-linux-x86_64-gnu-v1.0.0-alpha.83.zip" | sha256sum -c
-  unzip rustfs-linux-x86_64-gnu-v1.0.0-alpha.83.zip
-  rm rustfs-linux-x86_64-gnu-v1.0.0-alpha.83.zip
+  curl -LO https://github.com/rustfs/rustfs/releases/download/${VERSION}/rustfs-linux-x86_64-gnu-v${VERSION}.zip
+  echo "${SHA256SUM}  rustfs-linux-x86_64-gnu-v${VERSION}.zip" | sha256sum -c
+  unzip rustfs-linux-x86_64-gnu-v${VERSION}.zip
+  rm rustfs-linux-x86_64-gnu-v${VERSION}.zip
   { set +x; } 2>/dev/null
 fi
 


### PR DESCRIPTION
It's done:

- rustfs ZIP is downloaded, validated, uncompressed and binary is run
- rustfs docker image is not used anymore