### PR TITLE
go-build: simple golang compile workflow configured

### DIFF
--- a/.github/workflows/go-build.yaml
+++ b/.github/workflows/go-build.yaml
@@ -1,0 +1,41 @@
+name: Go Build
+
+on:
+  #push:
+  #  tags: ["*"]
+  #  branches: [ "main" ]
+  #pull_request:
+  #  branches: [ "main" ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: actions/checkout
+        uses: actions/checkout@v6
+
+      - name: actions/setup-go
+        uses: actions/setup-go@v6
+        with:
+          go-version: '1.26'
+          cache: true
+
+      - name: go mod tidy
+        run: go mod tidy
+
+      - name: go mod download
+        run: go mod download
+
+      - name: rm build
+        run: rm -rf build
+
+      - name: go build
+        run: go build -v -trimpath -buildvcs=false -ldflags="-s -w" -o build/i12e main.go
+
+      - name: go test
+        run: go test -v ./...


### PR DESCRIPTION
Skeleton is ready but it's untested provided that cannot be triggered from a branch.

- **actionlint** passes
- **on.workflow_dispatch** is the only trigger
- basic structure seems fine