### PR TITLE
i12e: 'main.go' provided with 'addOptBinToPath()' to find and use '/opt/bin/rclone'

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,7 +1,32 @@
 package main
 
-import "github.com/sfmunoz/i12e/cmd"
+import (
+	"os"
+	"slices"
+	"strings"
+
+	"github.com/sfmunoz/i12e/cmd"
+)
+
+// https://github.com/sfmunoz/i12e/issues/239
+func addOptBinToPath() {
+	sep := string(os.PathListSeparator)
+	optBin := "/opt/bin"
+	path := strings.TrimSpace(os.Getenv("PATH"))
+	if len(path) < 1 {
+		os.Setenv("PATH", optBin)
+		return
+	}
+	items := strings.Split(path, sep)
+	if slices.Contains(items, optBin) {
+		return
+	}
+	itemsNew := append([]string{optBin}, items...)
+	pathNew := strings.Join(itemsNew, ":")
+	os.Setenv("PATH", pathNew)
+}
 
 func main() {
+	addOptBinToPath()
 	cmd.Execute()
 }


### PR DESCRIPTION
Fixed: **/opt/bin** is added to **PATH** so **rclone** can be found and used