### PR TITLE
i12e: 'artifact-tune.sh->k3s_install()' sets 'INSTALL_K3S_SKIP_SELINUX_RPM=true'

### DIFF
--- a/internal/artifact/static/artifact-tune.sh
+++ b/internal/artifact/static/artifact-tune.sh
@@ -31,6 +31,7 @@ function k3s_install {
   echo "Installing k3s..."
   set -x
   export INSTALL_K3S_VERSION="v1.34.3+k3s1"
+  export INSTALL_K3S_SKIP_SELINUX_RPM="true"
   curl -sfL https://get.k3s.io | sh -s
   { set +x; } 2>/dev/null
 }


### PR DESCRIPTION
It's fixed: **INSTALL_K3S_SKIP_SELINUX_RPM=true** at **k3s** install time.