### PR TITLE
i12e: 'postgres-rclone' version updated from '0.0.7' to '0.0.8'

### DIFF
--- a/internal/server/postgres_rclone.go
+++ b/internal/server/postgres_rclone.go
@@ -45,7 +45,7 @@ func postgresRcloneYamlRender() (*bytes.Buffer, error) {
 		Namespace  string
 		RcloneConf *bytes.Buffer
 	}{
-		Version:    "0.0.7",
+		Version:    "0.0.8",
 		Namespace:  "i12e",
 		RcloneConf: bytes.NewBufferString(removeBlankLines(string(rcloneConf))),
 	}


### PR DESCRIPTION
**postgres-rclone** version has been updated from **0.0.7** to **0.0.8**